### PR TITLE
 refresh asyncPercentCompletion when waiting for report completed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ configurations {
     provided
 }
 
-version = "0.1.11"
+version = "0.1.12"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/org/embulk/input/facebook_ads_insights/Client.java
+++ b/src/main/java/org/embulk/input/facebook_ads_insights/Client.java
@@ -36,6 +36,7 @@ public class Client
 
     public List<AdsInsights> getInsights(boolean isPaginationValid) throws APIException, InterruptedException
     {
+        int elapsedTime = 0;
         boolean asyncCompleted = false;
         AdReportRun adReportRun = null;
         while (!asyncCompleted) {
@@ -61,18 +62,11 @@ public class Client
             logger.info(adReportRun.getRawResponse());
 
             String jobStatus = "";
-            int elapsedTime = 0;
-            long asyncPercentBefore = 0;
             try {
-                long asyncPercentCompletion = adReportRun.fetch().getFieldAsyncPercentCompletion();
-                while (asyncPercentCompletion != 100) {
+                while (adReportRun.fetch().getFieldAsyncPercentCompletion() != 100) {
                     logger.info(adReportRun.getRawResponse());
                     Thread.sleep(ASYNC_SLEEP_TIME);
-                    if (asyncPercentBefore != asyncPercentCompletion) {
-                        elapsedTime = 0;
-                    } else {
-                        elapsedTime += ASYNC_SLEEP_TIME;
-                    }
+                    elapsedTime += ASYNC_SLEEP_TIME;
                     if (adReportRun.getFieldAsyncStatus().equals("Job Skipped")) {
                         jobStatus = "skipped";
                         throw new RuntimeException("async was aborted because the AsyncStatus is \"Job Skipped\"");


### PR DESCRIPTION
`asyncPercentCompletion` が更新されず、無限ループになっていたため修正