### PR TITLE
add enable_debug option

### DIFF
--- a/src/main/java/org/embulk/input/facebook_ads_insights/Client.java
+++ b/src/main/java/org/embulk/input/facebook_ads_insights/Client.java
@@ -312,7 +312,9 @@ public class Client
 
     private APIContext apiContext()
     {
-        return new APIContext(pluginTask.getAccessToken());
+        APIContext context = new APIContext(pluginTask.getAccessToken());
+        context.enableDebug(this.pluginTask.getEnableDebug());
+        return context;
     }
     private List<String> fieldNames()
     {

--- a/src/main/java/org/embulk/input/facebook_ads_insights/PluginTask.java
+++ b/src/main/java/org/embulk/input/facebook_ads_insights/PluginTask.java
@@ -85,4 +85,8 @@ public interface PluginTask extends Task
     @Config("max_wait_seconds")
     @ConfigDefault("60")
     public Integer getMaxWaitSeconds();
+
+    @Config("enable_debug")
+    @ConfigDefault("false")
+    public boolean getEnableDebug();
 }


### PR DESCRIPTION
# 概要

`enableDebug(true)` を設定すると、以下のようにリクエストの詳細が見れるようになる。
```
========Start of API Call========
Request:
GET: https://graph.facebook.com/v11.0/923909328259914/?access_token=*****&fields=account_id%2Casync_percent_completion%2Casync_status%2Cdate_start%2Cdate_stop%2Cemails%2Cfriendly_name%2Cid%2Cis_bookmarked%2Cis_running%2Cschedule_id%2Ctime_completed%2Ctime_ref
Response:
{"account_id":"2360215384296886","async_percent_completion":100,"async_status":"Job Completed","date_start":"2021-08-11","date_stop":"2021-08-11","id":"923909328259914","time_completed":1637301290,"time_ref":1637301288}
========End of API Call========
```