### PR TITLE
use_unified_attribution_settingに対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Required Embulk version >= 0.9
 | time_range                      | no       | {since:YYYY-MM-DD, until:YYYY-MM-DD}                             | see [time_range](https://developers.facebook.com/docs/marketing-api/insights/parameters) for details.                      |
 | time_ranges                     | no       | array({since:YYYY-MM-DD, until:YYYY-MM-DD})                      | see [time_ranges](https://developers.facebook.com/docs/marketing-api/insights/parameters) for details.                     |
 | use_account_attribution_setting | no       | boolean                                                          | see [use_account_attribution_setting](https://developers.facebook.com/docs/marketing-api/insights/parameters) for details. |
+| use_unified_attribution_setting | no       | boolean                                                          | see [use_unified_attribution_setting](https://developers.facebook.com/docs/marketing-api/insights/parameters) for details. |
 
 ### Enums
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ configurations {
     provided
 }
 
-version = "0.1.12"
+version = "0.1.13"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/org/embulk/input/facebook_ads_insights/Client.java
+++ b/src/main/java/org/embulk/input/facebook_ads_insights/Client.java
@@ -158,6 +158,9 @@ public class Client
         if (pluginTask.getUseAccountAttributionSetting().isPresent()) {
             request.setUseAccountAttributionSetting(pluginTask.getUseAccountAttributionSetting().get());
         }
+        if (pluginTask.getUseUnifiedAttributionSetting().isPresent()) {
+            request.setUseUnifiedAttributionSetting(pluginTask.getUseUnifiedAttributionSetting().get());
+        }
         return request.execute();
     }
 
@@ -203,6 +206,9 @@ public class Client
         }
         if (pluginTask.getUseAccountAttributionSetting().isPresent()) {
             request.setUseAccountAttributionSetting(pluginTask.getUseAccountAttributionSetting().get());
+        }
+        if (pluginTask.getUseUnifiedAttributionSetting().isPresent()) {
+            request.setUseUnifiedAttributionSetting(pluginTask.getUseUnifiedAttributionSetting().get());
         }
         return request.execute();
     }
@@ -250,6 +256,9 @@ public class Client
         if (pluginTask.getUseAccountAttributionSetting().isPresent()) {
             request.setUseAccountAttributionSetting(pluginTask.getUseAccountAttributionSetting().get());
         }
+        if (pluginTask.getUseUnifiedAttributionSetting().isPresent()) {
+            request.setUseUnifiedAttributionSetting(pluginTask.getUseUnifiedAttributionSetting().get());
+        }
         return request.execute();
     }
 
@@ -295,6 +304,9 @@ public class Client
         }
         if (pluginTask.getUseAccountAttributionSetting().isPresent()) {
             request.setUseAccountAttributionSetting(pluginTask.getUseAccountAttributionSetting().get());
+        }
+        if (pluginTask.getUseUnifiedAttributionSetting().isPresent()) {
+            request.setUseUnifiedAttributionSetting(pluginTask.getUseUnifiedAttributionSetting().get());
         }
         return request.execute();
     }

--- a/src/main/java/org/embulk/input/facebook_ads_insights/PluginTask.java
+++ b/src/main/java/org/embulk/input/facebook_ads_insights/PluginTask.java
@@ -82,6 +82,10 @@ public interface PluginTask extends Task
     @ConfigDefault("null")
     public Optional<Boolean> getUseAccountAttributionSetting();
 
+    @Config("use_unified_attribution_setting")
+    @ConfigDefault("null")
+    public Optional<Boolean> getUseUnifiedAttributionSetting();
+
     @Config("max_wait_seconds")
     @ConfigDefault("60")
     public Integer getMaxWaitSeconds();


### PR DESCRIPTION
# 概要
https://developers.facebook.com/docs/marketing-api/insights/parameters/v13.0
`use_unified_attribution_setting`の対応

# 変更点
- `use_unified_attribution_setting`を扱えるように修正