### PR TITLE
Bump facebook-java-business-sdk to v18.0.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ targetCompatibility = 1.8
 dependencies {
     compile  "org.embulk:embulk-core:0.9.17"
     provided "org.embulk:embulk-core:0.9.17"
-    compile group: "com.facebook.business.sdk", name: "facebook-java-business-sdk", version: "17.0.3"
+    compile group: "com.facebook.business.sdk", name: "facebook-java-business-sdk", version: "18.0.4"
     // compile "YOUR_JAR_DEPENDENCY_GROUP:YOUR_JAR_DEPENDENCY_MODULE:YOUR_JAR_DEPENDENCY_VERSION"
     testCompile "junit:junit:4.+"
 }

--- a/src/main/java/org/embulk/input/facebook_ads_insights/AdsInsightsAccessor.java
+++ b/src/main/java/org/embulk/input/facebook_ads_insights/AdsInsightsAccessor.java
@@ -102,9 +102,6 @@ public class AdsInsightsAccessor
             case "place_page_name": return adsInsights.getFieldPlacePageName();
             case "purchase_roas": return actionsToString(adsInsights.getFieldPurchaseRoas());
             case "quality_ranking": return adsInsights.getFieldQualityRanking();
-            case "quality_score_ectr": return adsInsights.getFieldQualityScoreEctr();
-            case "quality_score_ecvr": return adsInsights.getFieldQualityScoreEcvr();
-            case "quality_score_organic": return adsInsights.getFieldQualityScoreOrganic();
             case "reach": return adsInsights.getFieldReach();
             case "social_spend": return adsInsights.getFieldSocialSpend();
             case "spend": return adsInsights.getFieldSpend();


### PR DESCRIPTION
Facebook Marketing API v17 will be EOL May 14, 2024.
https://developers.facebook.com/docs/graph-api/changelog/
<img width="916" alt="image" src="https://github.com/trocco-io/embulk-input-facebook_ads_insights/assets/2437917/9f30d186-187d-422a-a5fb-b25c232510f1">

Updated SDK to support API v18.